### PR TITLE
Lint error fixes made to cart.js to include arrow function

### DIFF
--- a/src/js/cart.js
+++ b/src/js/cart.js
@@ -4,23 +4,16 @@ function renderCartContents() {
   const cartItems = getLocalStorage("so-cart");
   let transformedCartItems;
 
-  // Check if cartItems is an array
   if (!Array.isArray(cartItems)) {
     // If cartItems is not an array, convert it to an array
     const cartItemsArray = cartItems ? [cartItems] : [];
     // Now you can use map() safely on cartItemsArray
-    transformedCartItems = cartItemsArray.map((item) => {
-      // Transformation logic
-      return cartItemTemplate(item);
-    });
+    transformedCartItems = cartItemsArray.map(item => cartItemTemplate(item));
   } else {
     // If cartItems is already an array, you can directly use map() on it
-    transformedCartItems = cartItems.map((item) => {
-      // Transformation logic
-      return cartItemTemplate(item);
-    });
+    transformedCartItems = cartItems.map(item => cartItemTemplate(item));
   }
-
+  
   // Set the innerHTML after mapping is done
   document.querySelector(".product-list").innerHTML = transformedCartItems.join("");
 }

--- a/src/js/product.js
+++ b/src/js/product.js
@@ -1,8 +1,8 @@
-import { setLocalStorage } from './utils.mjs';
-import { findProductById } from './productData.mjs';
+import { setLocalStorage } from "./utils.mjs";
+import { findProductById } from "./productData.mjs";
 
 function addProductToCart(product) {
-  setLocalStorage('so-cart', product);
+  setLocalStorage("so-cart", product);
 }
 // add to cart button event handler
 async function addToCartHandler(e) {
@@ -12,5 +12,5 @@ async function addToCartHandler(e) {
 
 // add listener to Add to Cart button
 document
-  .getElementById('addToCart')
-  .addEventListener('click', addToCartHandler);
+  .getElementById("addToCart")
+  .addEventListener("click", addToCartHandler);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,28 +1,28 @@
-import { resolve } from 'path';
-import { defineConfig } from 'vite';
+import { resolve } from "path";
+import { defineConfig } from "vite";
 
 export default defineConfig({
-  root: 'src/',
+  root: "src/",
 
   build: {
-    outDir: '../dist',
+    outDir: "../dist",
     rollupOptions: {
       input: {
-        main: resolve(__dirname, 'src/index.html'),
-        cart: resolve(__dirname, 'src/cart/index.html'),
-        checkout: resolve(__dirname, 'src/checkout/index.html'),
+        main: resolve(__dirname, "src/index.html"),
+        cart: resolve(__dirname, "src/cart/index.html"),
+        checkout: resolve(__dirname, "src/checkout/index.html"),
         product1: resolve(
           __dirname,
-          'src/product_pages/cedar-ridge-rimrock-2.html'
+          "src/product_pages/cedar-ridge-rimrock-2.html"
         ),
-        product2: resolve(__dirname, 'src/product_pages/marmot-ajax-3.html'),
+        product2: resolve(__dirname, "src/product_pages/marmot-ajax-3.html"),
         product3: resolve(
           __dirname,
-          'src/product_pages/northface-alpine-3.html'
+          "src/product_pages/northface-alpine-3.html"
         ),
         product4: resolve(
           __dirname,
-          'src/product_pages/northface-talus-4.html'
+          "src/product_pages/northface-talus-4.html"
         ),
       },
     },


### PR DESCRIPTION
There was an error encountered when I ran lint, it suggested that there was a `arrow-body-style` issue. 
This was due to the incorrect syntax being used for the arrow function, where was the message in the terminal: 

```
 > eslint *.js src/**/*.js

C:\Users\tyron\Desktop\wdd330_web_frontend_dev\sleepoutside\src\js\cart.js
  12:57  error  Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`  arrow-body-style
  18:52  error  Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`  arrow-body-style
```

Here was the previous code:

```
 // Check if cartItems is an array
  if (!Array.isArray(cartItems)) {
    // If cartItems is not an array, convert it to an array
    const cartItemsArray = cartItems ? [cartItems] : [];
    // Now you can use map() safely on cartItemsArray
    transformedCartItems = cartItemsArray.map((item) => {
      // Transformation logic
      return cartItemTemplate(item);
    });
  } else {
    // If cartItems is already an array, you can directly use map() on it
    transformedCartItems = cartItems.map((item) => {
      // Transformation logic
      return cartItemTemplate(item);
    });
  }

```

Here is suggested fix:

```
if (!Array.isArray(cartItems)) {
  const cartItemsArray = cartItems ? [cartItems] : [];
  transformedCartItems = cartItemsArray.map(item => cartItemTemplate(item));
} else {
  transformedCartItems = cartItems.map(item => cartItemTemplate(item));
}

```